### PR TITLE
`folder_selector` と `target_medias_selector` のリーダーを外す

### DIFF
--- a/lib/media_downloader/downloader.rb
+++ b/lib/media_downloader/downloader.rb
@@ -23,11 +23,6 @@ module MediaDownloader
     # @return [String]
     attr_reader :base_dir
 
-    # フォルダの選択に使うクラス
-    #
-    # @return [MediaDownloader::FolderSelector]
-    attr_reader :folder_selector
-
     # ダウンロード先のフォルダ
     #
     # @return [String]


### PR DESCRIPTION
## 概要

`folder_selector` と `target_medias_selector` のリーダーを外す。
いくらでも作れるインスタンスを外に見せても, コード量が増えるだけなので。

## 変更内容

`folder_selector` と `target_medias_selector` の `attr_reader` のコードを削除

## 影響範囲

なし

## 動作要件

なし

## 補足

なし