### PR TITLE
GitHub ActionsのSlack通知を失敗時のみに設定した

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Slack Notification
         uses: homoluctus/slatify@v1.6
-        if: always()
+        if: failure()
         with:
           job_name: '*Ruby CI*'
           type: ${{ job.status }}


### PR DESCRIPTION
## 概要

GitHub ActionsのSlack通知を失敗時のみに設定した。

## 変更内容

GitHub Actionsの`main.yml`の通知ステップの`if`を`failure()`に変更。

## 影響範囲

なし

## 動作要件

なし

## 補足

なし